### PR TITLE
fixed a type checking bug

### DIFF
--- a/func/send_coin.py
+++ b/func/send_coin.py
@@ -14,5 +14,5 @@ def send_coin(coin_amount,to_user):
     print("This is negative coin amount.")
     return None
 
-   print("sendcoin"+str(coin_amount))
-   send(my_public_key=my_public_key,my_private_key=my_private_key,to_user=to_user, amount = coin_amount)
+  print("sendcoin"+str(coin_amount))
+  send(my_public_key=my_public_key,my_private_key=my_private_key,to_user=to_user, amount = coin_amount)

--- a/func/send_coin.py
+++ b/func/send_coin.py
@@ -5,11 +5,14 @@ from wallet.wallet import Wallet_Import
 def send_coin(coin_amount,to_user):
   my_public_key = Wallet_Import(0,0)
   my_private_key = Wallet_Import(0,1)
+
+  if not (isinstance(coin_amount, int) or isinstance(coin_amount, float)):
+    print("This is not integer coin amount.")
+    return None
+
   if coin_amount < 0:
     print("This is negative coin amount.")
     return None
-  if isinstance(int(coin_amount), int) or isinstance(float(coin_amount), float):
+
    print("sendcoin"+str(coin_amount))
    send(my_public_key=my_public_key,my_private_key=my_private_key,to_user=to_user, amount = coin_amount)
-  else:
-    print("This is not integer coin amount.")


### PR DESCRIPTION
Hello, I am cpyberry.
If you happen to have a free moment, I'd be very glad if you could give me your opinion.

## Contents

* I removed explicit type conversion when checking types
* I changed to determine if coin_amount is negative before type checking

## Reasons

* If the type conversion fails, an exception will be thrown
* This allows strings, for example "1024"
* The processing when coin_amount is negative must be before the type check.